### PR TITLE
Add google adsense options.

### DIFF
--- a/public/ads.txt
+++ b/public/ads.txt
@@ -1,0 +1,1 @@
+google.com, pub-7797435335029081, DIRECT, f08c47fec0942fa0

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -8,6 +8,7 @@ export default async function RootLayout({ children }: Readonly<{ children: Reac
   return (
     <html lang="ko" suppressHydrationWarning className={cn(pretendard.className, 'scroll-smooth')}>
       <head>
+        <meta name="google-adsense-account" content="ca-pub-7797435335029081" />
         <script
           async
           src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-7797435335029081"


### PR DESCRIPTION
This pull request introduces support for Google AdSense by adding the necessary configuration and metadata. The changes include updating the `ads.txt` file and modifying the root layout to include AdSense-specific meta tags and scripts.

### Integration of Google AdSense:

* [`public/ads.txt`](diffhunk://#diff-ba3fcfc30256fb7ea9ff355d9e9ecbb0938a2d481e081fd26dfa22a6304a9f52R1): Added a new entry to configure Google AdSense with the publisher ID `pub-7797435335029081`.
* [`src/app/layout.tsx`](diffhunk://#diff-29d0a55f5ca1a9951042587f8b891bb4cd8b204f5bc855dc2468ed44cde2f5b3R11): Updated the `RootLayout` component to include a meta tag specifying the AdSense account and a script to load the AdSense library asynchronously.