### PR TITLE
Add coupang ads.

### DIFF
--- a/src/app/result/_components/ResultPageClient.tsx
+++ b/src/app/result/_components/ResultPageClient.tsx
@@ -8,6 +8,7 @@ import { games, traitInfo } from '@/lib/data'
 import { predict } from '@/lib/onnx'
 import type { TestData, PersonalityScores } from '@/lib/types'
 import { SEPERATE_TOKEN, zipData, unzipData } from '@/lib/utils'
+import { CoupangPartners } from '@/components/atoms/CoupangPartners'
 import { Footer } from '@/components/atoms/Footer'
 import ResultCard from '@/components/molecules/ResultCard'
 import AboutSection from '@/components/molecules/AboutSection'
@@ -254,6 +255,8 @@ function ResultContent() {
           error={recommendationError}
         />
 
+        <CoupangPartners />
+
         <Card className="animate-slide-up border-border bg-card text-center shadow-lg">
           <CardHeader>
             <CardTitle className="text-2xl text-foreground md:text-3xl">성격 분석 결과</CardTitle>
@@ -271,6 +274,8 @@ function ResultContent() {
             <ResultCard key={trait} trait={trait as keyof typeof traitInfo} score={score} />
           ))}
         </div>
+
+        <CoupangPartners />
 
         <AboutSection />
 

--- a/src/app/survey/_components/TestPageClient.tsx
+++ b/src/app/survey/_components/TestPageClient.tsx
@@ -8,6 +8,7 @@ import { questions, getGameClasses } from '@/lib/data'
 import type { TestData, UserAnswers } from '@/lib/types'
 import { cn, SEPERATE_TOKEN, zipData } from '@/lib/utils'
 import { calculateScores } from '@/lib/personality-calculator'
+import { CoupangPartners } from '@/components/atoms/CoupangPartners'
 import { SpriteIcon } from '@/components/molecules/RecommendationSection'
 import { Button } from '@/components/ui/button'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
@@ -141,6 +142,8 @@ function TestContent() {
             <p className="text-muted-foreground">더 정확한 분석을 위해 현재 직업 정보를 알려주세요</p>
           </div>
         </header>
+
+        <CoupangPartners />
 
         <main className="mx-auto max-w-6xl px-4 pb-8">
           <div className="space-y-8">
@@ -327,6 +330,8 @@ function TestContent() {
           </p>
         </div>
       </header>
+
+      <CoupangPartners />
 
       <main className="mx-auto max-w-4xl px-4 pb-24">
         <Card className="animate-slide-up border-border bg-card shadow-lg">

--- a/src/components/atoms/CoupangPartners.tsx
+++ b/src/components/atoms/CoupangPartners.tsx
@@ -1,0 +1,16 @@
+import Image from 'next/image'
+
+export const CoupangPartners = () => {
+  return (
+    <div className="my-2 flex justify-center">
+      <a href="https://link.coupang.com/a/cFAw9h" target="_blank" referrerPolicy="unsafe-url">
+        <Image
+          src="https://ads-partners.coupang.com/banners/888491?subId=&traceId=V0-301-5f9bd61900e673c0-I888491&w=728&h=90"
+          alt=""
+          width={728}
+          height={90}
+        />
+      </a>
+    </div>
+  )
+}

--- a/src/components/atoms/Home.tsx
+++ b/src/components/atoms/Home.tsx
@@ -13,6 +13,7 @@ import type { Game } from '@/lib/types'
 import type { Metadata } from 'next'
 import { Footer } from '@/components/atoms/Footer'
 import { Header } from '@/components/atoms/Header'
+import { CoupangPartners } from '@/components/atoms/CoupangPartners'
 
 export const metadata: Metadata = {
   title: `성격 분석 결과 | Big5 게임 직업 추천`,
@@ -160,6 +161,7 @@ export default function Home() {
           </CardContent>
         </Card>
       </main>
+      <CoupangPartners />
       <Footer />
     </div>
   )


### PR DESCRIPTION
This pull request introduces a new `CoupangPartners` component to display a banner advertisement and integrates it across multiple pages in the application. The changes ensure consistent placement of the banner while maintaining the existing layout and functionality.

### New Component Implementation:
* [`src/components/atoms/CoupangPartners.tsx`](diffhunk://#diff-43c909062bdbafe32bd38e2b46905a2682c4b7f2a8d0d32ac56ec60f3684409aR1-R16): Added the `CoupangPartners` component, which displays a clickable banner ad using the `next/image` component. The banner links to an external Coupang affiliate URL.

### Integration of `CoupangPartners` Component:
* **Result Page (`ResultPageClient.tsx`)**:
  - Imported the `CoupangPartners` component.
  - Added the `CoupangPartners` banner in two locations: above the result card and above the about section. [[1]](diffhunk://#diff-43bc424cee52515ce6413cbf2ec508299ed01d8595b1fba40f38197d1e3168d7R258-R259) [[2]](diffhunk://#diff-43bc424cee52515ce6413cbf2ec508299ed01d8595b1fba40f38197d1e3168d7R278-R279)

* **Survey Page (`TestPageClient.tsx`)**:
  - Imported the `CoupangPartners` component.
  - Added the `CoupangPartners` banner in two locations: below the header and above the main content. [[1]](diffhunk://#diff-b976885eeecd86ce998dbad849119aae614f4850e4ce7517538502016d57b481R146-R147) [[2]](diffhunk://#diff-b976885eeecd86ce998dbad849119aae614f4850e4ce7517538502016d57b481R334-R335)

* **Home Page (`Home.tsx`)**:
  - Imported the `CoupangPartners` component.
  - Added the `CoupangPartners` banner above the footer.